### PR TITLE
update-dependencies: Change guzzle version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "sensio/framework-extra-bundle": "^5.2",
         "symfony/monolog-bundle": "^3.6",
         "myclabs/php-enum": "^1.7",
-        "guzzlehttp/guzzle": "^6.0|^7.0.*"
+        "guzzlehttp/guzzle": "^6.0|^7.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "sensio/framework-extra-bundle": "^5.2",
         "symfony/monolog-bundle": "^3.6",
         "myclabs/php-enum": "^1.7",
-        "guzzlehttp/guzzle": "^6.0"
+        "guzzlehttp/guzzle": "^6.0|7.0.*"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
         "sensio/framework-extra-bundle": "^5.2",
         "symfony/monolog-bundle": "^3.6",
         "myclabs/php-enum": "^1.7",
-        "guzzlehttp/guzzle": "^6.0|7.0.*"
+        "guzzlehttp/guzzle": "^6.0|^7.0.*"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
https://lead-in.monday.com/boards/72721864/pulses/2100551652
**For testing**
`docker exec -it pl3-php composer require leadin/symfony-survival-kit:dev-update-dependencies`

This command should install symfony-surivial-kit on pl3 with the hash of the last commit of this branch